### PR TITLE
Fix infinite recursion case from dstack

### DIFF
--- a/pydantic_duality/__init__.py
+++ b/pydantic_duality/__init__.py
@@ -51,7 +51,7 @@ def _resolve_annotation(annotation, attr: str) -> Any:
             get_origin(annotation),
             tuple(_resolve_annotation(a, attr) for a in get_args(annotation)),
         )
-    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+    if inspect.isclass(annotation) and isinstance(annotation, ModelMetaclass):
         return annotation
     if get_origin(annotation) is Union:
         return Union.__getitem__(tuple(_resolve_annotation(a, attr) for a in get_args(annotation)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-duality"
-version = "1.2.3"
+version = "1.2.4"
 description = "Automatically generate two versions of your pydantic models: one with Extra.forbid and one with Extra.ignore"
 repository = "https://github.com/zmievsa/pydantic-duality"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ branch = true
 fail_under = 90
 skip_covered = true
 skip_empty = true
+omit = ["tests/*"]
 # Taken from https://coverage.readthedocs.io/en/7.1.0/excluding.html#advanced-exclusion
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
Sadly, I have no idea why this fixes their issue but it makes no difference in terms of duality's logic so might as well include it :)

Somehow with their combination of actions an `issubclass(str, BaseModel)` actually calls `DualBaseModel.__subclasshook__`